### PR TITLE
Various problems when the layer is disabled

### DIFF
--- a/range_sensor_layer/src/range_sensor_layer.cpp
+++ b/range_sensor_layer/src/range_sensor_layer.cpp
@@ -139,6 +139,8 @@ void RangeSensorLayer::reconfigureCB(costmap_2d::GenericPluginConfig &config, ui
 
 void RangeSensorLayer::incomingRange(const sensor_msgs::RangeConstPtr& range)
 {
+  if (!enabled_) { return; }
+
   double r = range->range;
 
   bool clear_sensor_cone = false;
@@ -245,9 +247,9 @@ void RangeSensorLayer::incomingRange(const sensor_msgs::RangeConstPtr& range)
   bx1 = std::min((int)size_x_, bx1);
   by1 = std::min((int)size_y_, by1);
 
-  for (unsigned int x = bx0; x <= (unsigned int)bx1; x++)
+  for (unsigned int x = bx0; x <= std::abs(bx1); x++)
   {
-    for (unsigned int y = by0; y <= (unsigned int)by1; y++)
+    for (unsigned int y = by0; y <= std::abs(by1); y++)
     {
       double wx, wy;
       mapToWorld(x, y, wx, wy);


### PR DESCRIPTION
Range sensor layer hangs when it is disabled via the dynamic reconfigure variable `enabled`.

Root cause:
- When disabled, incoming data gets processed for every cell. The bounds for the cells are sometimes negative. These bounds however are cast with `(unsigned int)`, which, if intended to work like `std::abs` is failing (e.g. `(unsigned int)-11 = 4294967285`). 
- When disabled, it shouldn't process incomings at all.

This isn't a perfect fix yet though:
- Is `incomingRange()` is a subscriber callaback, quite likely happening in a different thread to the rest of the class functions. If `incomingRange()` is dependent on the class state, lack of mutex's is a worry.
- Should bounds ever be negative? The fact that he has unsigned int might imply yeah, but I'm only seeing it when I disable the layer (and hence quite likely it is just an erroneous internal state causing havoc).
